### PR TITLE
Feature/configurable statq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode
+Gopkg.*
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 Newest updates are at the top of this file.
 
+### Apr 20 2020 
+* Update to allow configure the STATQ for each queue object (PUT,GET,OPENCLOSE,INQSET)
+
 ### Apr 02 2020 
 * Update to use v4.1.4 of the mq-golang repository
 

--- a/cmd/mq_prometheus/exporter.go
+++ b/cmd/mq_prometheus/exporter.go
@@ -239,8 +239,9 @@ func (e *exporter) Collect(ch chan<- prometheus.Metric) {
 	if config.cf.RediscoverDuration > 0 {
 		if elapsed >= config.cf.RediscoverDuration {
 			s := config.cf.MonitoredQueues
+			statq := config.cf.MonitoredSTATQ
 			log.Debugf("Doing queue rediscovery")
-			err = mqmetric.RediscoverAndSubscribe(s, true, "")
+			err = mqmetric.RediscoverAndSubscribe(s, true, statq, "")
 			lastQueueDiscovery = thisDiscovery
 			//if err == nil {
 			err = mqmetric.RediscoverAttributes(ibmmq.MQOT_CHANNEL, config.cf.MonitoredChannels)

--- a/cmd/mq_prometheus/main.go
+++ b/cmd/mq_prometheus/main.go
@@ -68,7 +68,7 @@ func main() {
 		}
 
 		mqmetric.SetLocale(config.locale)
-		err = mqmetric.DiscoverAndSubscribe(config.cf.MonitoredQueues, wildcardResource, config.cf.MetaPrefix)
+		err = mqmetric.DiscoverAndSubscribe(config.cf.MonitoredQueues, wildcardResource, config.cf.MonitoredSTATQ, config.cf.MetaPrefix)
 		mqmetric.RediscoverAttributes(ibmmq.MQOT_CHANNEL, config.cf.MonitoredChannels)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,9 +24,10 @@ package config
 import (
 	"flag"
 	"fmt"
+	"time"
+
 	"github.com/ibm-messaging/mq-golang/mqmetric"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 // Configuration attributes shared by all the monitor sample programs
@@ -40,6 +41,7 @@ type Config struct {
 
 	MonitoredQueues            string
 	MonitoredQueuesFile        string
+	MonitoredSTATQ             string
 	MonitoredChannels          string
 	MonitoredChannelsFile      string
 	MonitoredTopics            string
@@ -77,6 +79,7 @@ func InitConfig(cm *Config) {
 	// Note that there are non-empty defaults for Topics and Subscriptions
 	flag.StringVar(&cm.MonitoredQueues, "ibmmq.monitoredQueues", "", "Patterns of queues to monitor")
 	flag.StringVar(&cm.MonitoredQueuesFile, "ibmmq.monitoredQueuesFile", "", "File with patterns of queues to monitor")
+	flag.StringVar(&cm.MonitoredSTATQ, "ibmmq.monitoredSTATQ", "", "Patterns of STATQ metrics to monitor")
 	flag.StringVar(&cm.MonitoredChannels, "ibmmq.monitoredChannels", "", "Patterns of channels to monitor")
 	flag.StringVar(&cm.MonitoredChannelsFile, "ibmmq.monitoredChannelsFile", "", "File with patterns of channels to monitor")
 	flag.StringVar(&cm.MonitoredTopics, "ibmmq.monitoredTopics", "#", "Patterns of topics to monitor")


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [ x] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-metricsamples/CLA.md)
- [ ] You have added tests for any code changes
- [ x] You have updated the [CHANGELOG.md](https://github.com/ibm-messaging/mq-metric-samples/CHANGELOG.md)
- [x ] You have completed the PR template below:

## What
I am suggesting add a new configuration parameter MonitoredSTATQ which allows configure the STATQ (PUT,GET,OPENCLOSE,INQSET) for each queue object e.g. subscribe for only PUT and GET or any other combination

## How
The reason is I have QMs with large number of queues and I am not really interested in some of those stats per queue. Here is an example of using only PUT,GET instead of all STATQ:
queues 2716
subscriptions  5445 instead of 10877
messages 5445 instead of 10867
There is no real difference in the zipped file size (10.5 MB instead of 11.7 MB) but a huge difference in subscriptions and messages generated during each publish interval. The difference is also big in terms of time series (with PUT,GET only I get more than 103.000 time series)

## Testing
Performed test locally and verified in test environment. 
Example 1:
- add to mq_prometheus.sh
   ARGS="$ARGS -ibmmq.monitoredSTATQ=PUT,GET"
- run mq_prometheus
- using MQ-Explorer verify only PUT,GET subscriptions are created for each local queue
Example 2:
- do not add monitoredSTATQ. It defaults to "". 
- run mq_prometheus
- using MQ-Explorer verify all subscriptions are created for each local queue
Example 3:
- add to mq_prometheus.sh a "wrong" value:
   ARGS="$ARGS -ibmmq.monitoredSTATQ=PUT,GETx"
- run mq_prometheus
- you get following error:
time="2020-04-20T11:48:59+02:00" level=fatal msg="Invalid value for monitored STATQ: Object pattern 'GETx' is not valid. Available values are 'GET OPENCLOSE INQSET PUT '" 

## Issues

Links to the github issue(s) (if present) that this pull request is resolving.
