### PR TITLE
Update Dockerfile.run to fix error when running under OpenShift restricted SCC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 Newest updates are at the top of this file.
 
+### Apr 5 2021
+* Update Dockerfile.run to prevent permissions errors when running in OpenShift restricted SCC
+
 ### Mar 26 2021
 * Update to use v5.2.0 of the mq-golang repository
 * Update to use MQ 9.2.2

--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -44,7 +44,11 @@ RUN cd /opt/mqm \
  && curl -LO "$RDURL/$VRMF-$RDTAR" \
  && tar -zxf ./*.tar.gz \
  && rm -f ./*.tar.gz \
- && bin/genmqpkg.sh -b /opt/mqm
+ && bin/genmqpkg.sh -b /opt/mqm \
+ && mkdir -p /IBM/MQ/data/errors \
+   && mkdir -p /.mqm \
+   && chmod -R 777 /IBM \
+   && chmod -R 777 /.mqm
 
 ENV LD_LIBRARY_PATH="/opt/mqm/lib64:/usr/lib64" \
     MQ_CONNECT_TYPE=CLIENT


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-metricsamples/CLA.md)
- [ ] N/A.  You have added tests for any code changes
- [x] You have updated the [CHANGELOG.md](https://github.com/ibm-messaging/mq-metric-samples/CHANGELOG.md)
- [x] You have completed the PR template below:

## What

Updated Dockerfile.run to create basic directories required by the MQ client, which cannot be created dynamically when the container is deployed using the OpenShift "restricted SCC" due to lack of permissions for that user.

## How

Added extra config lines to Dockerfile.run to match those used for this scenario elsewhere

## Testing

Verified by deploying updated container to OpenShift cluster and observing resolution of the original error

## Issues

N/A
