### PR TITLE
Adjust Dockerfile.run parameters to allow easier override configuration at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 Newest updates are at the top of this file.
 
+### Apr 8 2021
+* Update Dockerfile.run to move default configuration params to environment variables
+
 ### Apr 5 2021
 * Update Dockerfile.run to prevent permissions errors when running in OpenShift restricted SCC
 

--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -60,5 +60,9 @@ RUN echo "Building container for $MONITOR"
 # Copy over the binary file, which is in the same directory as this one
 COPY $MONITOR /opt/bin/$MONITOR
 
+# Set default values for some configuration settings
+ENV IBMMQ_GLOBAL_CONFIGURATIONFILE=/opt/config/$MONITOR.yaml
+ENV IBMMQ_GLOBAL_LOGLEVEL=info
+
 # The configuration file should be mounted from the host into the /opt/config directory.
-CMD /opt/bin/$MONITOR -f /opt/config/$MONITOR.yaml -log.level=info
+CMD /opt/bin/$MONITOR


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-metricsamples/CLA.md)
- [ ] N/A  You have added tests for any code changes
- [x] You have updated the [CHANGELOG.md](https://github.com/ibm-messaging/mq-metric-samples/CHANGELOG.md)
- [x] You have completed the PR template below:

## What
Updated Dockerfile.run to move the two parameters that are applied in the "CMD" element so that they are set as environment variables, which allows those values to be updated/overridden/unset at runtime without having to modify the Dockerfile.

## How
Modification to Dockerfile.run

## Testing
Local testing to confirm that the default behaviour is the same before/after the change, and that setting an environment variable when starting the container is able to override/unset those defaults.

Also confirmed the variable expansion continues to work as expected.

## Issues
N/A
