### PR TITLE
Don't check for QMGR name unless config parse was a success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 Newest updates are at the top of this file.
 
+### Apr 15 2021
+* Don't check for QMGR name unless config parse was a success
+
 ### Apr 8 2021
 * Update Dockerfile.run to move default configuration params to environment variables
 

--- a/cmd/mq_prometheus/main.go
+++ b/cmd/mq_prometheus/main.go
@@ -47,7 +47,7 @@ func main() {
 	// Print this because it's easy to get the escapes wrong from a shell script with wildcarded topics ('#')
 	log.Debugf("Monitored topics are '%s'", config.cf.MonitoredTopics)
 
-	if config.cf.QMgrName == "" {
+	if err == nil && config.cf.QMgrName == "" {
 		log.Errorln("Must provide a queue manager name to connect to.")
 		os.Exit(72) // Same as strmqm "queue manager name error"
 	}


### PR DESCRIPTION
Fixes #64, where parse errors where not being detected.  The
condition only checked for the presence of QMGR name.  By adding
the err == nil check, we continue on with the error handling strategy

Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-metricsamples/CLA.md)
- [ ] You have added tests for any code changes
- [x] You have updated the [CHANGELOG.md](https://github.com/ibm-messaging/mq-metric-samples/CHANGELOG.md)
- [x] You have completed the PR template below:

## What

Error handling code in mq_prometheus was improved to propagate parse errors in config file.

## How

If a config file is missing or has parsing errors the errors are silently ignored, due to the check of qmgr name before checking the return value of the config parsing.  This change skips the mqgr name check if the return value is not nil,
causing the error strategy to continue on, resulting in an error being logged.

## Testing

Automatic testing is not easily added to code in the main function.  This has been tested manualliy by running against:
* valid config file
* missing config file
* invalid config file
* no config file parameter

## Issues

#64 