### PR TITLE
fix(build-info): buildinfo should be prented in stdErr not stdOut

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -402,15 +402,15 @@ func VerifyConfig(cm *Config, fullCf interface{}) error {
 func PrintInfo(title string, stamp string, commit string, buildPlatform string) {
 	fmt.Fprintln(os.Stderr, title)
 	if stamp != "" {
-		fmt.Fprintln(os.Stderr, "Build         : "+stamp)
+		fmt.Fprintf(os.Stderr, "Build         : %s\n", stamp)
 	}
 	if commit != "" {
-		fmt.Fprintln(os.Stderr, "Commit Level  : "+commit)
+		fmt.Fprintf(os.Stderr, "Commit Level  : %s\n", commit)
 	}
 	if buildPlatform != "" {
-		fmt.Fprintln(os.Stderr, "Build Platform: "+buildPlatform)
+		fmt.Fprintf(os.Stderr, "Build Platform: %s\n", buildPlatform)
 	}
-	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintf(os.Stderr, "\n")
 }
 
 func InitLog(cm Config) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,13 +24,14 @@ package config
 import (
 	"flag"
 	"fmt"
-	"github.com/ibm-messaging/mq-golang/v5/mqmetric"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/ibm-messaging/mq-golang/v5/mqmetric"
+	log "github.com/sirupsen/logrus"
 )
 
 // Configuration attributes shared by all the monitor sample programs
@@ -399,17 +400,17 @@ func VerifyConfig(cm *Config, fullCf interface{}) error {
 }
 
 func PrintInfo(title string, stamp string, commit string, buildPlatform string) {
-	fmt.Println(title)
+	fmt.Fprintln(os.Stderr, title)
 	if stamp != "" {
-		fmt.Println("Build         : " + stamp)
+		fmt.Fprintln(os.Stderr, "Build         : "+stamp)
 	}
 	if commit != "" {
-		fmt.Println("Commit Level  : " + commit)
+		fmt.Fprintln(os.Stderr, "Commit Level  : "+commit)
 	}
 	if buildPlatform != "" {
-		fmt.Println("Build Platform: " + buildPlatform)
+		fmt.Fprintln(os.Stderr, "Build Platform: "+buildPlatform)
 	}
-	fmt.Println("")
+	fmt.Fprintln(os.Stderr, "")
 }
 
 func InitLog(cm Config) {


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-metricsamples/CLA.md)
- [ ] You have updated the [CHANGELOG.md](https://github.com/ibm-messaging/mq-metric-samples/CHANGELOG.md). 
- [x] You have completed the PR template below:

## What
This Pr aligns to standardize the output of the build-info log moving it to stdErr, for three main reasons:
 - The exporter always prints all logs of any level to `os.stdErr` (default of logrus) as well as issues parsing args (default of  `flag.CommandLine.Output()` is again stdErr)
 - The build info and title conceptually are an info/debug log and not an output of the exporter, therefore I believe they should go to stdErr instead of stdOut. 
 - Running it manually no change is noticed. But in our use case (wrapping the exporter to control its lifecycle) we do not get any warning due to an output not structured that cannot be parsed. 

## How
Changing `Println([...])` for `Fprintln(os.Stderr,[...])`

## Issues

https://github.com/newrelic/newrelic-prometheus-exporters-packages/issues/108


Let me know if you have any concerns about the change! 😄 