### PR TITLE
Add Dockerfile with multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ ENV EXPORTER=${EXPORTER} \
 RUN mkdir -p /opt/bin \
     && chmod -R 777 /opt/bin \
     && mkdir -p /opt/mqm \
-    && chmod a+rx /opt/mqm \
+    && chmod 775 /opt/mqm \
     && mkdir -p /opt/config \
     && chmod a+rx /opt/config
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,99 @@
+# syntax=docker/dockerfile:1
+
+# Global ARG. To be used in all stages.
+ARG EXPORTER=mq_prometheus
+
+# --- --- --- --- --- --- --- --- --- --- --- --- --- --- #
+## ### ### ### ### ### ### BUILD ### ### ### ### ### ### ##
+# --- --- --- --- --- --- --- --- --- --- --- --- --- --- #
+FROM golang:1.19 AS builder
+
+ARG EXPORTER
+
+ENV EXPORTER=${EXPORTER} \
+    ORG="github.com/ibm-messaging" \
+    REPO="mq-metric-samples" \
+    RDURL="https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist" \
+    RDTAR="IBM-MQC-Redist-LinuxX64.tar.gz" \
+    VRMF=9.3.1.0 \
+    CGO_CFLAGS="-I/opt/mqm/inc/" \
+    CGO_LDFLAGS_ALLOW="-Wl,-rpath.*" \
+    genmqpkg_incnls=1 \
+    genmqpkg_incsdk=1 \
+    genmqpkg_inctls=1
+
+# Install packages
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    build-essential
+
+# Create directory structure
+RUN mkdir -p /go/src /go/bin /go/pkg \
+    && chmod -R 777 /go \
+    && mkdir -p /go/src/$ORG \
+    && mkdir -p /opt/mqm \
+    && chmod a+rx /opt/mqm
+
+# Install MQ client
+WORKDIR /opt/mqm
+RUN curl -LO "$RDURL/$VRMF-$RDTAR" \
+    && tar -zxf ./*.tar.gz \
+    && rm -f ./*.tar.gz \
+    && bin/genmqpkg.sh -b /opt/mqm
+
+# Build Go application
+WORKDIR /go/src/$ORG/$REPO
+COPY go.mod .
+COPY go.sum .
+COPY --chmod=777 ./cmd/${EXPORTER} .
+COPY vendor ./vendor
+COPY pkg ./pkg
+RUN go build -mod=vendor -o /go/bin/${EXPORTER} ./*.go
+
+# --- --- --- --- --- --- --- --- --- --- --- --- --- --- #
+### ### ### ### ### ### ### RUN ### ### ### ### ### ### ###
+# --- --- --- --- --- --- --- --- --- --- --- --- --- --- #
+FROM golang:1.19
+
+ARG EXPORTER
+
+ENV EXPORTER=${EXPORTER} \
+    RDURL="https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist" \
+    RDTAR="IBM-MQC-Redist-LinuxX64.tar.gz" \
+    VRMF=9.3.1.0 \
+    genmqpkg_incnls=1 \
+    genmqpkg_incsdk=1 \
+    genmqpkg_inctls=1 \
+    LD_LIBRARY_PATH="/opt/mqm/lib64:/usr/lib64" \
+    MQ_CONNECT_TYPE=CLIENT \
+    IBMMQ_GLOBAL_CONFIGURATIONFILE=/opt/config/${EXPORTER}.yaml
+
+# Create directory structure
+RUN mkdir -p /opt/bin \
+    && chmod -R 777 /opt/bin \
+    && mkdir -p /opt/mqm \
+    && chmod a+rx /opt/mqm \
+    && mkdir -p /opt/config \
+    && chmod a+rx /opt/config
+
+# Install packages
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install MQ client 
+WORKDIR /opt/mqm
+RUN curl -LO "$RDURL/$VRMF-$RDTAR" \
+    && tar -zxf ./*.tar.gz \
+    && rm -f ./*.tar.gz \
+    && bin/genmqpkg.sh -b /opt/mqm \
+    && mkdir -p /IBM/MQ/data/errors \
+    && mkdir -p /.mqm \
+    && chmod -R 777 /IBM \
+    && chmod -R 777 /.mqm
+
+COPY --chmod=777 --from=builder /go/bin/${EXPORTER} /opt/bin/${EXPORTER}
+
+CMD ["sh", "-c", "/opt/bin/${EXPORTER}"]


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer's Certificate of Origin](https://github.com/ibm-messaging/mq-metric-samples/DCO1.1.txt)
- [x] You have added tests for any code changes
- [ ] You have updated the [CHANGELOG.md](https://github.com/ibm-messaging/mq-metric-samples/CHANGELOG.md)
- [x] You have completed the PR template below:

## What

I found it extraordinarily difficult to build and run the `mq_prometheus` exporter using the provided Dockerfiles and shell scripts. The environment variables, paths, and copying files from and to the host make the entire process cumbersome.

Hence, I added a Dockerfile that enhances the build process. It uses [multi-stage builds](https://docs.docker.com/build/building/multi-stage/), which is the state-of-the-art and preferred way, compared to using multiple Dockerfiles and copying files from Docker container to host and vice versa.

Now, we must simply run one single command. All steps are executed irrespective of the underlying host. Hence, we do not need different scripts for Linux and Windows machines.

## How

The Dockerfile consists of two stages. The first stage builds the Go application and copies the binary to the second stage, which builds a runtime for the Go application.

## Testing

Run `docker build -t {tag}:{version} .` in the root folder of the repository. Then, start the Docker image, e.g., with `./scripts/docker-compose.yml`.

## Issues

This pull-request is not linked to any currently open issues.