### PR TITLE
fix(mq_prometheus): correct first collection logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Newest updates are at the top of this file.
 
+### Unreleased
+* Fix boolean logic for `isFirstCollection` in `mq_prometheus`
+  * Ensure proper collection on the first poll and at regular intervals thereafter
+
 ### Feb 28 2025 (v5.6.2)
 * Update to MQ 9.4.2
 * The "nhainstance" tag is renamed to "nha" to handle both instances and CRR groups

--- a/cmd/mq_prometheus/exporter.go
+++ b/cmd/mq_prometheus/exporter.go
@@ -268,7 +268,7 @@ func (e *exporter) Collect(ch chan<- prometheus.Metric) {
 		pollStatus = false
 		thisPoll := time.Now()
 		elapsed = thisPoll.Sub(lastPoll)
-		if elapsed >= config.cf.PollIntervalDuration || !isFirstCollection() {
+		if elapsed >= config.cf.PollIntervalDuration || isFirstCollection() {
 			log.Debugf("Polling for object status")
 			lastPoll = thisPoll
 			pollStatus = true


### PR DESCRIPTION
The boolean logic for `isFirstCollection` was flipped in commit `11efdcdcb9d576bd5c7a87a1f19925dba4e4ac71`. This caused `!isFirstCollection()` to evaluate to false on the first poll, and true after the first poll interval, leading to frequent status polling instead of adhering to `global.pollInterval`.

This commit corrects the logic to ensure proper collection on the first poll and at regular intervals thereafter.

Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer's Certificate of Origin](https://github.com/ibm-messaging/mq-metric-samples/DCO1.1.txt)
- [x] ~~You have added tests for any code changes~~. Prometheus part does not contain any tests.
- [x] You have updated the [CHANGELOG.md](https://github.com/ibm-messaging/mq-metric-samples/CHANGELOG.md)
- [x] You have completed the PR template below:

## What

fix(mq_prometheus): correct first collection logic

## How

The boolean logic for `isFirstCollection` was flipped in commit [`11efdcdcb9d576bd5c7a87a1f19925dba4e4ac71`](https://github.com/ibm-messaging/mq-metric-samples/commit/11efdcdcb9d576bd5c7a87a1f19925dba4e4ac71#diff-dd2270000f6437799fac0fa73051ba7b13a2dc91cd79cd0d2d53b04ad1f91eefL33-L200). This caused `!isFirstCollection()` to evaluate to false on the first poll, and true after the first poll interval, leading to frequent status polling instead of adhering to `global.pollInterval`.

## Testing

Local debugging.

## Issues

New issue. Detected while testing prometheus exporter.
