### PR TITLE
feat: Add showCustomAttribute filter config setting to include the CUSTOM attribute as tag/label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Newest updates are at the top of this file.
 ### Unreleased
 * Fix boolean logic for `isFirstCollection` in `mq_prometheus (#385)`
   * Ensure proper collection on the first poll and at regular intervals thereafter
+* Add showCustomAttribute filter config setting to include the CUSTOM attribute as metric tag/label
 
 ### Feb 28 2025 (v5.6.2)
 * Update to MQ 9.4.2

--- a/cmd/mq_aws/exporter.go
+++ b/cmd/mq_aws/exporter.go
@@ -251,6 +251,9 @@ func Collect() error {
 								if hostname != mqmetric.DUMMY_STRING {
 									tags["hostname"] = hostname
 								}
+								if showAndSupportsCustomLabel() {
+									tags["custom"] = mqmetric.GetObjectCustom("", ibmmq.MQOT_Q_MGR)
+								}
 							} else if strings.HasPrefix(key, mqmetric.NativeHAKeyPrefix) {
 								series = "nha"
 								tags["nha"] = strings.Replace(key, mqmetric.NativeHAKeyPrefix, "", -1)
@@ -270,6 +273,9 @@ func Collect() error {
 								tags["usage"] = usage
 								tags["description"] = mqmetric.GetObjectDescription(key, ibmmq.MQOT_Q)
 								tags["cluster"] = mqmetric.GetQueueAttribute(key, ibmmq.MQCA_CLUSTER_NAME)
+								if showAndSupportsCustomLabel() {
+									tags["custom"] = mqmetric.GetObjectCustom(key, ibmmq.MQOT_Q)
+								}
 							}
 							addMetaLabels(tags)
 
@@ -351,6 +357,9 @@ func Collect() error {
 						tags["usage"] = usage
 						tags["description"] = mqmetric.GetObjectDescription(key, ibmmq.MQOT_Q)
 						tags["cluster"] = mqmetric.GetQueueAttribute(key, ibmmq.MQCA_CLUSTER_NAME)
+						if showAndSupportsCustomLabel() {
+							tags["custom"] = mqmetric.GetObjectCustom(key, ibmmq.MQOT_Q)
+						}
 						addMetaLabels(tags)
 
 						f := mqmetric.QueueNormalise(attr, value.ValueInt64)
@@ -475,6 +484,9 @@ func Collect() error {
 						hostname := mqmetric.GetQueueManagerAttribute(config.cf.QMgrName, ibmmq.MQCACF_HOST_NAME)
 						if hostname != mqmetric.DUMMY_STRING {
 							tags["hostname"] = hostname
+						}
+						if showAndSupportsCustomLabel() {
+							tags["custom"] = mqmetric.GetObjectCustom("", ibmmq.MQOT_Q_MGR)
 						}
 						addMetaLabels(tags)
 
@@ -639,4 +651,8 @@ func addMetaLabels(tags map[string]string) {
 			tags[config.cf.MetadataTagsArray[i]] = config.cf.MetadataValuesArray[i]
 		}
 	}
+}
+
+func showAndSupportsCustomLabel() bool {
+	return config.cf.CC.ShowCustomAttribute
 }

--- a/cmd/mq_coll/exporter.go
+++ b/cmd/mq_coll/exporter.go
@@ -205,6 +205,9 @@ func Collect() error {
 								if hostname != mqmetric.DUMMY_STRING {
 									tags["hostname"] = hostname
 								}
+								if showAndSupportsCustomLabel() {
+									tags["custom"] = mqmetric.GetObjectCustom("", ibmmq.MQOT_Q_MGR)
+								}
 							} else if strings.HasPrefix(key, mqmetric.NativeHAKeyPrefix) {
 								series = "nha"
 								tags["nha"] = strings.Replace(key, mqmetric.NativeHAKeyPrefix, "", -1)
@@ -223,6 +226,9 @@ func Collect() error {
 								tags["usage"] = usage
 								tags["description"] = mqmetric.GetObjectDescription(key, ibmmq.MQOT_Q)
 								tags["cluster"] = mqmetric.GetQueueAttribute(key, ibmmq.MQCA_CLUSTER_NAME)
+								if showAndSupportsCustomLabel() {
+									tags["custom"] = mqmetric.GetObjectCustom(key, ibmmq.MQOT_Q)
+								}
 							}
 							addMetaLabels(tags)
 
@@ -290,6 +296,9 @@ func Collect() error {
 					tags["usage"] = usage
 					tags["description"] = mqmetric.GetObjectDescription(key, ibmmq.MQOT_Q)
 					tags["cluster"] = mqmetric.GetQueueAttribute(key, ibmmq.MQCA_CLUSTER_NAME)
+					if showAndSupportsCustomLabel() {
+						tags["custom"] = mqmetric.GetObjectCustom(key, ibmmq.MQOT_Q)
+					}
 					addMetaLabels(tags)
 
 					f := mqmetric.QueueNormalise(attr, value.ValueInt64)
@@ -388,6 +397,9 @@ func Collect() error {
 					hostname := mqmetric.GetQueueManagerAttribute(config.cf.QMgrName, ibmmq.MQCACF_HOST_NAME)
 					if hostname != mqmetric.DUMMY_STRING {
 						tags["hostname"] = hostname
+					}
+					if showAndSupportsCustomLabel() {
+						tags["custom"] = mqmetric.GetObjectCustom("", ibmmq.MQOT_Q_MGR)
 					}
 					addMetaLabels(tags)
 
@@ -529,4 +541,8 @@ func addMetaLabels(tags map[string]string) {
 			tags[config.cf.MetadataTagsArray[i]] = config.cf.MetadataValuesArray[i]
 		}
 	}
+}
+
+func showAndSupportsCustomLabel() bool {
+	return config.cf.CC.ShowCustomAttribute
 }

--- a/cmd/mq_influx/exporter.go
+++ b/cmd/mq_influx/exporter.go
@@ -236,6 +236,9 @@ func Collect(c client.Client) error {
 								if hostname != mqmetric.DUMMY_STRING {
 									tags["hostname"] = hostname
 								}
+								if showAndSupportsCustomLabel() {
+									tags["custom"] = mqmetric.GetObjectCustom("", ibmmq.MQOT_Q_MGR)
+								}
 							} else if strings.HasPrefix(key, mqmetric.NativeHAKeyPrefix) {
 								series = "nha"
 								tags["nha"] = strings.Replace(key, mqmetric.NativeHAKeyPrefix, "", -1)
@@ -255,6 +258,9 @@ func Collect(c client.Client) error {
 								tags["usage"] = usage
 								tags["description"] = mqmetric.GetObjectDescription(key, ibmmq.MQOT_Q)
 								tags["cluster"] = mqmetric.GetQueueAttribute(key, ibmmq.MQCA_CLUSTER_NAME)
+								if showAndSupportsCustomLabel() {
+									tags["custom"] = mqmetric.GetObjectCustom(key, ibmmq.MQOT_Q)
+								}
 								addMetaLabels(tags)
 
 							}
@@ -329,6 +335,9 @@ func Collect(c client.Client) error {
 						tags["usage"] = usage
 						tags["description"] = mqmetric.GetObjectDescription(key, ibmmq.MQOT_Q)
 						tags["cluster"] = mqmetric.GetQueueAttribute(key, ibmmq.MQCA_CLUSTER_NAME)
+						if showAndSupportsCustomLabel() {
+							tags["custom"] = mqmetric.GetObjectCustom(key, ibmmq.MQOT_Q)
+						}
 						addMetaLabels(tags)
 
 						f := mqmetric.QueueNormalise(attr, value.ValueInt64)
@@ -446,6 +455,9 @@ func Collect(c client.Client) error {
 						hostname := mqmetric.GetQueueManagerAttribute(config.cf.QMgrName, ibmmq.MQCACF_HOST_NAME)
 						if hostname != mqmetric.DUMMY_STRING {
 							tags["hostname"] = hostname
+						}
+						if showAndSupportsCustomLabel() {
+							tags["custom"] = mqmetric.GetObjectCustom("", ibmmq.MQOT_Q_MGR)
 						}
 						addMetaLabels(tags)
 
@@ -573,4 +585,8 @@ func addMetaLabels(tags map[string]string) {
 			tags[config.cf.MetadataTagsArray[i]] = config.cf.MetadataValuesArray[i]
 		}
 	}
+}
+
+func showAndSupportsCustomLabel() bool {
+	return config.cf.CC.ShowCustomAttribute
 }

--- a/cmd/mq_json/exporter.go
+++ b/cmd/mq_json/exporter.go
@@ -233,6 +233,9 @@ func Collect() error {
 								if hostname != mqmetric.DUMMY_STRING {
 									pt.Tags["hostname"] = hostname
 								}
+								if showAndSupportsCustomLabel() {
+									pt.Tags["custom"] = mqmetric.GetObjectCustom("", ibmmq.MQOT_Q_MGR)
+								}
 							} else if strings.HasPrefix(key, mqmetric.NativeHAKeyPrefix) {
 								pt.Tags["nha"] = strings.Replace(key, mqmetric.NativeHAKeyPrefix, "", -1)
 								pt.ObjectType = "nha"
@@ -244,7 +247,9 @@ func Collect() error {
 								pt.ObjectType = "queue"
 								pt.Tags["description"] = mqmetric.GetObjectDescription(key, ibmmq.MQOT_Q)
 								pt.Tags["cluster"] = mqmetric.GetQueueAttribute(key, ibmmq.MQCA_CLUSTER_NAME)
-
+								if showAndSupportsCustomLabel() {
+									pt.Tags["custom"] = mqmetric.GetObjectCustom(key, ibmmq.MQOT_Q)
+								}
 							}
 							addMetaLabels(pt.Tags)
 						}
@@ -327,6 +332,9 @@ func Collect() error {
 									pt.Tags["queue"] = qName
 									pt.Tags["usage"] = usageString
 									pt.Tags["description"] = mqmetric.GetObjectDescription(qName, ibmmq.MQOT_Q)
+									if showAndSupportsCustomLabel() {
+										pt.Tags["custom"] = mqmetric.GetObjectCustom(qName, ibmmq.MQOT_Q)
+									}
 									pt.Tags["cluster"] = mqmetric.GetQueueAttribute(key, ibmmq.MQCA_CLUSTER_NAME)
 									pt.Tags["platform"] = platformString
 									addMetaLabels(pt.Tags)
@@ -382,6 +390,9 @@ func Collect() error {
 									pt.Tags["qmgr"] = strings.TrimSpace(qMgrName)
 									pt.Tags["platform"] = platformString
 									pt.Tags["description"] = mqmetric.GetObjectDescription("", ibmmq.MQOT_Q_MGR)
+									if showAndSupportsCustomLabel() {
+										pt.Tags["custom"] = mqmetric.GetObjectCustom("", ibmmq.MQOT_Q_MGR)
+									}
 									hostname := mqmetric.GetQueueManagerAttribute(config.cf.QMgrName, ibmmq.MQCACF_HOST_NAME)
 									if hostname != mqmetric.DUMMY_STRING {
 										pt.Tags["hostname"] = hostname
@@ -649,4 +660,8 @@ func addMetaLabels(tags map[string]string) {
 			tags[config.cf.MetadataTagsArray[i]] = config.cf.MetadataValuesArray[i]
 		}
 	}
+}
+
+func showAndSupportsCustomLabel() bool {
+	return config.cf.CC.ShowCustomAttribute
 }

--- a/cmd/mq_opentsdb/exporter.go
+++ b/cmd/mq_opentsdb/exporter.go
@@ -236,6 +236,9 @@ func Collect() error {
 								if hostname != mqmetric.DUMMY_STRING {
 									tags["hostname"] = hostname
 								}
+								if showAndSupportsCustomLabel() {
+									tags["custom"] = mqmetric.GetObjectCustom("", ibmmq.MQOT_Q_MGR)
+								}
 							} else if strings.HasPrefix(key, mqmetric.NativeHAKeyPrefix) {
 								series = "nha"
 								tags["nha"] = strings.Replace(key, mqmetric.NativeHAKeyPrefix, "", -1)
@@ -254,7 +257,9 @@ func Collect() error {
 								tags["usage"] = usage
 								tags["description"] = mqmetric.GetObjectDescription(key, ibmmq.MQOT_Q)
 								tags["cluster"] = mqmetric.GetQueueAttribute(key, ibmmq.MQCA_CLUSTER_NAME)
-
+								if showAndSupportsCustomLabel() {
+									tags["custom"] = mqmetric.GetObjectCustom(key, ibmmq.MQOT_Q)
+								}
 							}
 							addMetaLabels(tags)
 
@@ -335,6 +340,9 @@ func Collect() error {
 						tags["usage"] = usage
 						tags["description"] = mqmetric.GetObjectDescription(key, ibmmq.MQOT_Q)
 						tags["cluster"] = mqmetric.GetQueueAttribute(key, ibmmq.MQCA_CLUSTER_NAME)
+						if showAndSupportsCustomLabel() {
+							tags["custom"] = mqmetric.GetObjectCustom(key, ibmmq.MQOT_Q)
+						}
 						addMetaLabels(tags)
 
 						f := mqmetric.QueueNormalise(attr, value.ValueInt64)
@@ -456,6 +464,9 @@ func Collect() error {
 						hostname := mqmetric.GetQueueManagerAttribute(config.cf.QMgrName, ibmmq.MQCACF_HOST_NAME)
 						if hostname != mqmetric.DUMMY_STRING {
 							tags["hostname"] = hostname
+						}
+						if showAndSupportsCustomLabel() {
+							tags["custom"] = mqmetric.GetObjectCustom("", ibmmq.MQOT_Q_MGR)
 						}
 						addMetaLabels(tags)
 
@@ -661,4 +672,8 @@ func addMetaLabels(tags map[string]string) {
 			tags[config.cf.MetadataTagsArray[i]] = config.cf.MetadataValuesArray[i]
 		}
 	}
+}
+
+func showAndSupportsCustomLabel() bool {
+	return config.cf.CC.ShowCustomAttribute
 }

--- a/cmd/mq_otel/reader.go
+++ b/cmd/mq_otel/reader.go
@@ -361,6 +361,9 @@ func GetMetrics(ctx context.Context, meter metric.Meter) error {
 								if hostname != mqmetric.DUMMY_STRING {
 									tags["hostname"] = hostname
 								}
+								if showAndSupportsCustomLabel() {
+									tags["custom"] = mqmetric.GetObjectCustom("", ibmmq.MQOT_Q_MGR)
+								}
 							} else if strings.HasPrefix(key, mqmetric.NativeHAKeyPrefix) {
 								series = "nha"
 								tags["nha"] = strings.Replace(key, mqmetric.NativeHAKeyPrefix, "", -1)
@@ -379,6 +382,9 @@ func GetMetrics(ctx context.Context, meter metric.Meter) error {
 								tags["usage"] = usage
 								tags["description"] = mqmetric.GetObjectDescription(key, ibmmq.MQOT_Q)
 								tags["cluster"] = mqmetric.GetQueueAttribute(key, ibmmq.MQCA_CLUSTER_NAME)
+								if showAndSupportsCustomLabel() {
+									tags["custom"] = mqmetric.GetObjectCustom(key, ibmmq.MQOT_Q)
+								}
 							}
 
 							addMetaLabels(tags)
@@ -413,6 +419,9 @@ func GetMetrics(ctx context.Context, meter metric.Meter) error {
 						tags["usage"] = usage
 						tags["description"] = mqmetric.GetObjectDescription(key, ibmmq.MQOT_Q)
 						tags["cluster"] = mqmetric.GetQueueAttribute(key, ibmmq.MQCA_CLUSTER_NAME)
+						if showAndSupportsCustomLabel() {
+							tags["custom"] = mqmetric.GetObjectCustom(key, ibmmq.MQOT_Q)
+						}
 						addMetaLabels(tags)
 
 						f := mqmetric.QueueNormalise(attr, value.ValueInt64)
@@ -549,6 +558,9 @@ func GetMetrics(ctx context.Context, meter metric.Meter) error {
 						if hostname != mqmetric.DUMMY_STRING {
 							tags["hostname"] = hostname
 						}
+						if showAndSupportsCustomLabel() {
+							tags["custom"] = mqmetric.GetObjectCustom("", ibmmq.MQOT_Q_MGR)
+						}
 						addMetaLabels(tags)
 
 						f := mqmetric.QueueManagerNormalise(attr, value.ValueInt64)
@@ -656,4 +668,8 @@ func addMetaLabels(tags map[string]string) {
 			tags[config.cf.MetadataTagsArray[i]] = config.cf.MetadataValuesArray[i]
 		}
 	}
+}
+
+func showAndSupportsCustomLabel() bool {
+	return config.cf.CC.ShowCustomAttribute
 }

--- a/config.common.yaml
+++ b/config.common.yaml
@@ -92,6 +92,9 @@ filters:
     - PUT
     - GET
     - GENERAL
+    # Setting this to "true" will include the CUSTOM attribute of a queue manager and queue as
+    # tag/label.
+    showCustomAttribute: false
 
 # Collector-specific configuration will also need to be added here. Some of the sample build
 # scripts will concatenate default definitions from the cmd/mq_* directories.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -189,6 +189,7 @@ func InitConfig(cm *Config) {
 	AddParm(&cm.MonitoredSubscriptionsFile, "", CP_STR, "ibmmq.monitoredSubscriptionsFile", "objects", "subscriptionsFile", "File with patterns of subscriptions to monitor")
 	AddParm(&cm.QueueSubscriptionSelector, "", CP_STR, "ibmmq.queueSubscriptionSelector", "filters", "queueSubscriptionSelector", "Resource topic selection for queues")
 	AddParm(&cm.CC.ShowInactiveChannels, false, CP_BOOL, "ibmmq.showInactiveChannels", "filters", "showInactiveChannels", "Show inactive channels (not just stopped ones)")
+	AddParm(&cm.CC.ShowCustomAttribute, false, CP_BOOL, "ibmmq.showCustomAttribute", "filters", "showCustomAttribute", "Include custom attribute in metrics")
 
 	AddParm(&cm.CC.HideSvrConnJobname, false, CP_BOOL, "ibmmq.hideSvrConnJobname", "filters", "hideSvrConnJobname", "Don't create multiple instances of SVRCONN information")
 	AddParm(&cm.CC.HideAMQPClientId, false, CP_BOOL, "ibmmq.hideAMQPClientId", "filters", "hideAMQPClientId", "Don't create multiple instances of ClientID information")

--- a/pkg/config/configyaml.go
+++ b/pkg/config/configyaml.go
@@ -72,6 +72,7 @@ type ConfigYFilters struct {
 	HideSvrConnJobname        string   `yaml:"hideSvrConnJobname" default:"false"`
 	HideAMQPClientId          string   `yaml:"hideAMQPClientId" default:"false"`
 	ShowInactiveChannels      string   `yaml:"showInactiveChannels" default:"false"`
+	ShowCustomAttribute       string   `yaml:"showCustomAttribute" default:"false"`
 	QueueSubscriptionSelector []string `yaml:"queueSubscriptionSelector"`
 }
 
@@ -130,6 +131,7 @@ func CopyYamlConfig(cm *Config, cyg ConfigYGlobal, cyc ConfigYConnection, cyo Co
 	cm.CC.UsePublications = CopyParmIfNotSetBool("global", "usePublications", AsBool(cyg.UsePublications, true))
 
 	cm.CC.ShowInactiveChannels = CopyParmIfNotSetBool("filters", "showInactiveChannels", AsBool(cyf.ShowInactiveChannels, false))
+	cm.CC.ShowCustomAttribute = CopyParmIfNotSetBool("filters", "showCustomAttribute", AsBool(cyf.ShowCustomAttribute, false))
 	cm.CC.HideSvrConnJobname = CopyParmIfNotSetBool("filters", "hideSvrConnJobname", AsBool(cyf.HideSvrConnJobname, false))
 	cm.CC.HideAMQPClientId = CopyParmIfNotSetBool("filters", "hideAMQPClientId", AsBool(cyf.HideAMQPClientId, false))
 

--- a/vendor/github.com/ibm-messaging/mq-golang/v5/mqmetric/discover.go
+++ b/vendor/github.com/ibm-messaging/mq-golang/v5/mqmetric/discover.go
@@ -87,6 +87,7 @@ type ObjInfo struct {
 	exists          bool // Used during rediscovery
 	firstCollection bool // To indicate discard needed of first stat
 	Description     string
+	Custom          string
 	// Qmgr attributes
 	QMgrName string
 	HostName string
@@ -1625,6 +1626,25 @@ func GetObjectDescription(key string, objectType int32) string {
 		return DUMMY_STRING
 	} else {
 		return o.Description
+	}
+}
+
+func GetObjectCustom(key string, objectType int32) string {
+	var o *ObjInfo
+	ok := false
+	switch objectType {
+	case ibmmq.MQOT_Q:
+		o, ok = qInfoMap[key]
+	case OT_Q_MGR:
+		o = qMgrInfo
+		ok = true
+	}
+
+	if !ok || strings.TrimSpace(o.Custom) == "" {
+		// return something so Prometheus doesn't turn it into "0.0"
+		return DUMMY_STRING
+	} else {
+		return o.Custom
 	}
 }
 

--- a/vendor/github.com/ibm-messaging/mq-golang/v5/mqmetric/globals.go
+++ b/vendor/github.com/ibm-messaging/mq-golang/v5/mqmetric/globals.go
@@ -53,6 +53,7 @@ type connectionInfo struct {
 	useResetQStats       bool
 	useDepthFromStatus   bool
 	showInactiveChannels bool
+	showCustomAttribute  bool
 	hideSvrConnJobname   bool
 	hideAMQPClientId     bool
 
@@ -140,6 +141,7 @@ func newConnectionInfo(key string) *connectionInfo {
 	ci.useStatus = false
 	ci.useResetQStats = false
 	ci.showInactiveChannels = false
+	ci.showCustomAttribute = false
 	ci.hideSvrConnJobname = false
 	ci.hideAMQPClientId = false
 

--- a/vendor/github.com/ibm-messaging/mq-golang/v5/mqmetric/mqif.go
+++ b/vendor/github.com/ibm-messaging/mq-golang/v5/mqmetric/mqif.go
@@ -52,6 +52,7 @@ type ConnectionConfig struct {
 	UseStatus            bool
 	UseResetQStats       bool
 	ShowInactiveChannels bool
+	ShowCustomAttribute  bool
 	HideSvrConnJobname   bool
 	HideAMQPClientId     bool
 	WaitInterval         int
@@ -131,6 +132,7 @@ func initConnectionKey(key string, qMgrName string, replyQ string, replyQ2 strin
 
 	ci.tzOffsetSecs = cc.TZOffsetSecs
 	ci.showInactiveChannels = cc.ShowInactiveChannels
+	ci.showCustomAttribute = cc.ShowCustomAttribute
 	ci.hideSvrConnJobname = cc.HideSvrConnJobname
 	ci.hideAMQPClientId = cc.HideAMQPClientId
 

--- a/vendor/github.com/ibm-messaging/mq-golang/v5/mqmetric/qmgr.go
+++ b/vendor/github.com/ibm-messaging/mq-golang/v5/mqmetric/qmgr.go
@@ -187,6 +187,10 @@ func collectQueueManagerAttrsZOS() error {
 		ibmmq.MQIA_TCP_CHANNELS,
 		ibmmq.MQIA_MAX_CHANNELS}
 
+	if ci.showCustomAttribute {
+		selectors = append(selectors, ibmmq.MQCA_CUSTOM)
+	}
+
 	v, err := ci.si.qMgrObject.Inq(selectors)
 	if err == nil {
 		maxchls := v[ibmmq.MQIA_MAX_CHANNELS].(int32)
@@ -204,6 +208,9 @@ func collectQueueManagerAttrsZOS() error {
 		st.Attributes[ATTR_QMGR_STATUS].Values[key] = newStatusValueInt64(int64(ibmmq.MQQMSTA_RUNNING))
 		qMgrInfo.Description = desc
 		qMgrInfo.QMgrName = key
+		if ci.showCustomAttribute {
+			qMgrInfo.Custom = v[ibmmq.MQCA_CUSTOM].(string)
+		}
 	}
 	traceExitErr("collectQueueManagerAttrsZOS", 0, err)
 
@@ -217,16 +224,19 @@ func collectQueueManagerAttrsDist() error {
 	st := GetObjectStatus(GetConnectionKey(), OT_Q_MGR)
 
 	selectors := []int32{ibmmq.MQCA_Q_MGR_NAME,
-		ibmmq.MQCA_Q_MGR_DESC}
+		ibmmq.MQCA_Q_MGR_DESC, ibmmq.MQCA_CUSTOM}
 
 	v, err := ci.si.qMgrObject.Inq(selectors)
 	desc := DUMMY_STRING
+	custom := DUMMY_STRING
 	if err == nil {
 		key := v[ibmmq.MQCA_Q_MGR_NAME].(string)
 		desc = v[ibmmq.MQCA_Q_MGR_DESC].(string)
+		custom = v[ibmmq.MQCA_CUSTOM].(string)
 		st.Attributes[ATTR_QMGR_NAME].Values[key] = newStatusValueString(key)
 		qMgrInfo.Description = desc
 		qMgrInfo.QMgrName = key
+		qMgrInfo.Custom = custom
 	}
 
 	traceExitErr("collectQueueManagerAttrsDist", 0, err)

--- a/vendor/github.com/ibm-messaging/mq-golang/v5/mqmetric/queue.go
+++ b/vendor/github.com/ibm-messaging/mq-golang/v5/mqmetric/queue.go
@@ -358,6 +358,9 @@ func inquireQueueAttributes(objectPatternsList string) error {
 		pcfparm.Type = ibmmq.MQCFT_INTEGER_LIST
 		pcfparm.Parameter = ibmmq.MQIACF_Q_ATTRS
 		pcfparm.Int64Value = []int64{int64(ibmmq.MQIA_MAX_Q_DEPTH), int64(ibmmq.MQIA_USAGE), int64(ibmmq.MQIA_DEFINITION_TYPE), int64(ibmmq.MQCA_Q_DESC), int64(ibmmq.MQCA_CLUSTER_NAME)}
+		if ci.showCustomAttribute {
+			pcfparm.Int64Value = append(pcfparm.Int64Value, int64(ibmmq.MQCA_CUSTOM))
+		}
 		cfh.ParameterCount++
 		buf = append(buf, pcfparm.Bytes()...)
 
@@ -597,6 +600,14 @@ func parseQAttrData(cfh *ibmmq.MQCFH, buf []byte) {
 			if v != "" {
 				if qInfo, ok := qInfoMap[qName]; ok {
 					qInfo.Description = printableStringUTF8(v)
+				}
+			}
+
+		case ibmmq.MQCA_CUSTOM:
+			v := elem.String[0]
+			if v != "" {
+				if qInfo, ok := qInfoMap[qName]; ok {
+					qInfo.Custom = printableStringUTF8(v)
 				}
 			}
 


### PR DESCRIPTION
Adds new `filters.showCustomAttribute` config setting to add the CUSTOM attribute data from a queue manager or queue as metrics tag/label.

Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer's Certificate of Origin](https://github.com/ibm-messaging/mq-metric-samples/DCO1.1.txt)
- [x] You have updated the [CHANGELOG.md](https://github.com/ibm-messaging/mq-metric-samples/CHANGELOG.md)
- [x] You have completed the PR template below:

## What

We have the requirement to annotate queue manager and queue metrics with a custom tag or label. This information helps query the metrics based on this custom label and create alerts based on this information.
The CUSTOM attribute on [queue manager](https://www.ibm.com/docs/en/ibm-mq/9.4.0?topic=reference-define-queues#q085690___custom) and queue level can be utilized for this kind of additional information. As an IBM MQ platform team we will set `CUSTOM("APP(A0123)")` on a queue manager or on a queue. The new capability in this PR extracts this CUSTOM data and adds it as a tag or label depending on the collector.

## How

The query request of the queue manager and queue attributes was extended to include the `ibmmq.MQCA_CUSTOM` data.

## Testing

The change was tested locally for otel, prometheus and JSON exporter.

## Issues

-

## Open point

1.  The changes to `[mq-golang](https://github.com/ibm-messaging/mq-golang)` were commited to the vendor folder as it's not clear how to bring the changes upstream. Should a pull request opened at [mq-golang](https://github.com/ibm-messaging/mq-golang)?
2. Since I don't have any expirience with IBM MQ for z/OS I'm not sure if the custom attribute is supported in that platform. For that reason the `showAndSupportsCustomLabel` method was created to mark it false if the platform does not support it.