### PR TITLE
chore: add internal build support using private repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,12 @@
 # Override with "--build-arg EXPORTER=mq_xxxxx" when building.
 ARG EXPORTER=mq_prometheus
 
+# Runtime base image.
+# This must be declared before the first FROM so Docker BuildKit
+# can correctly expand it when selecting the runtime image.
+# Override with: docker build --build-arg RUNTIME_IMAGE=<image> .
+ARG RUNTIME_IMAGE=registry.access.redhat.com/ubi8-minimal:latest
+
 # --- --- --- --- --- --- --- --- --- --- --- --- --- --- #
 ## ### ### ### ### ### ### BUILD ### ### ### ### ### ### ##
 # --- --- --- --- --- --- --- --- --- --- --- --- --- --- #
@@ -37,19 +43,29 @@ ENV EXPORTER=${EXPORTER} \
 ENV GOVERSION=1.22.8
 USER 0
 
+# Go module / toolchain proxy used during the build.
+# This affects both the Go toolchain download and any module downloads.
+# Override with: docker build --build-arg GOPROXY=<proxy-url> .
+# Default is the public Go proxy.
+ARG GOPROXY=https://proxy.golang.org,direct
+RUN go env -w GOPROXY="$GOPROXY"
+
 # The base UBI8 image does not (currently) contain the most
 # recent Go compiler. Which tends to be required for the OTel
-# packages. So we have to explicitly download and install it.
-# As long as we've got SOME level of compiler (which this base image)
-# does have, we can use it to pull down the more recent levels. It appears as if a
-# "go build ..." will now actually automatically pull in the newer level if needed
-# by the go.mod directives. But let's be explicit.
-RUN go install golang.org/dl/go${GOVERSION}@latest
-
-# The compiler is in a non-default location. For the UBI8 image,
-# this is where it ends up.
-ENV GO=/opt/app-root/src/go/bin/go${GOVERSION}
-RUN $GO download && $GO version
+# packages.
+# Go (1.21+) provides automatic toolchain selection via GOTOOLCHAIN.
+# The Go version specified in this image (via GOVERSION) is installed
+# by the Go toolchain and automatically downloaded if not present.
+# In restricted environments, this requires GOPROXY to point to an
+# internal repository.
+# As long as the base image includes some Go compiler, the required Go version
+# can be automatically downloaded and used when needed (for example, based on
+# go.mod directives), without explicitly installing it in the image.
+ENV GOTOOLCHAIN="go${GOVERSION}+auto"
+RUN go version 
+ENV GO=go
+RUN echo "GO version"
+RUN go version 
 
 # Create directory structure
 RUN mkdir -p /go/src /go/bin /go/pkg \
@@ -149,7 +165,7 @@ RUN buildStamp=`date +%Y%m%d-%H%M%S`; \
 ### ### ### ### ### ### ### RUN ### ### ### ### ### ### ###
 # --- --- --- --- --- --- --- --- --- --- --- --- --- --- #
 # Use a "minimal" runtime image
-FROM registry.access.redhat.com/ubi8-minimal:latest AS runtime
+FROM ${RUNTIME_IMAGE} AS runtime
 
 ARG EXPORTER
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -29,14 +29,22 @@ ENV GOPATH=$GOPATH_ARG \
 
 ENV GOVERSION=1.22.8
 
+# Go module / toolchain proxy used during the build.
+# This affects both the Go toolchain download and any module downloads.
+# Override with: docker build --build-arg GOPROXY=<proxy-url> .
+# Default is the public Go proxy.
+ARG GOPROXY=https://proxy.golang.org,direct
+RUN go env -w GOPROXY="$GOPROXY"
+
 USER 0
 RUN mkdir -p /go && chmod 777 /go
-RUN go install golang.org/dl/go${GOVERSION}@latest
 
-# The compiler is in a non-default location. For the UBI8 image,
-# this is where it ends up.
-ENV GO=/go/bin/go${GOVERSION}
-RUN $GO download && $GO version
+# Go is installed automatically by the Go toolchain using GOTOOLCHAIN.
+ENV GOTOOLCHAIN="go${GOVERSION}+auto"
+RUN go version 
+ENV GO=go
+RUN echo "GO version"
+RUN go version 
 
 # Create location for the git clone and MQ installation
 RUN mkdir -p $GOPATH/src $GOPATH/bin $GOPATH/pkg $GOPATH/out \
@@ -46,8 +54,9 @@ RUN mkdir -p $GOPATH/src $GOPATH/bin $GOPATH/pkg $GOPATH/out \
   && mkdir -p /opt/mqm \
   && chmod a+rx /opt/mqm
 
-# Location of the downloadable MQ client package \
-ENV RDURL="https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist" \
+# Location of the downloadable MQ client package
+ARG RDURL_ARG="https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist"
+ENV RDURL=${RDURL_ARG} \
     RDTAR="IBM-MQC-Redist-Linux${MQARCH}.tar.gz" \
     VRMF=9.4.5.0
 

--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 # Use a "minimal" runtime image
-FROM registry.access.redhat.com/ubi8-minimal:latest AS runtime
+ARG RUNTIME_IMAGE=registry.access.redhat.com/ubi8-minimal:latest
+FROM ${RUNTIME_IMAGE} AS runtime
 
 ARG GOARCH=amd64
 ARG MQARCH=X64
@@ -29,7 +30,8 @@ RUN mkdir -p /opt/bin \
 RUN microdnf install -y --disableplugin=subscription-manager curl tar gzip findutils
 
 # Location of the downloadable MQ client package \
-ENV RDURL="https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist" \
+ARG RDURL_ARG="https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist"
+ENV RDURL=${RDURL_ARG} \
     RDTAR="IBM-MQC-Redist-Linux${MQARCH}.tar.gz" \
     VRMF=9.4.5.0
 


### PR DESCRIPTION
Allow overriding base images, Go proxy, and MQ client URL for internal builds  
Use Go `GOTOOLCHAIN` for toolchain management  
Enable building with only internal (non-public) resources  

- [x]   I have signed off my agreement to the Developer's Certificate of Origin
- [ ] I have added tests for any code changes
- [ ] I have updated the [CHANGELOG.md](https://github.com/ibm-messaging/mq-metric-samples/CHANGELOG.md)
- [x] I  have completed the PR template

## What

Enhanced Docker build support for restricted/internal environments by allowing all external dependencies to be overridden.

Specifically:

- Allow overriding the runtime base image via `RUNTIME_IMAGE`
- Allow overriding the Go module/toolchain proxy via `GOPROXY`
- Use Go `GOTOOLCHAIN` for toolchain management
- Allow overriding the MQ client download URL via `RDURL_ARG` in `Dockerfile.build` and `Dockerfile.run`  
  (the main `Dockerfile` already supports passing the MQ client URL as a build argument)

---

## How

- Added `ARG RUNTIME_IMAGE` and updated runtime stages to:

  ```dockerfile
  FROM ${RUNTIME_IMAGE} AS runtime
  ```

  This allows builds to use internal container registries instead of the default public UBI image.

- Added `ARG GOPROXY` and configured:

  ```dockerfile
  RUN go env -w GOPROXY="$GOPROXY"
  ```

  This enables module and toolchain downloads to be routed through an internal Go proxy in restricted environments.

- Replaced explicit Go toolchain installation with Go's built-in toolchain management:

  ```dockerfile
  ENV GOTOOLCHAIN="go${GOVERSION}+auto"
  ```

  This configures the build to use Go `${GOVERSION}` (e.g. 1.22.8).  
  If that version is not already present, the Go command automatically downloads and uses the required toolchain, subject to the configured `GOPROXY`.  
  This removes the need to manually install a specific Go binary in the image.

- Added `ARG RDURL_ARG` in `Dockerfile.build` and `Dockerfile.run`, and set:

  ```dockerfile
  ENV RDURL=${RDURL_ARG}
  ```

  This removes the hardcoded dependency on the public IBM MQ redistributable URL and allows use of an internal artifact repository.

---

## Testing

Validated both default (public internet) builds and internal (restricted) builds.

### Build the build-stage image

```bash
docker build --no-cache -f Dockerfile.build -t mq-metric-prometheus-build \
  --build-arg BASE_IMAGE=<internal-registry>/ubi8/go-toolset:1.21 \
  --build-arg RDURL_ARG=https://<internal-registry>/artifactory/ibm-mq-redist-generic-remote \
  --build-arg GOPROXY=https://<internal-registry>/artifactory/api/go/go-virtual \
  .
```

### Run the build image to produce monitor binaries

```bash
docker run --rm -v "$PWD/output":/go/out mq-metric-prometheus-build
cp output/mq_prometheus .
```

### Build the runtime image

```bash
docker build -f Dockerfile.run -t mq-metric-prometheus \
  --build-arg RUNTIME_IMAGE=<internal-registry>/ubi8-minimal:latest \
  --build-arg RDURL_ARG=https://<internal-registry>/artifactory/ibm-mq-redist-generic-remote \
  .
```

### Build the combined (build-and-run) image

```bash
docker build --no-cache -t mq-metric-prometheus\
  --build-arg BASE_IMAGE=<internal-registry>/ubi8/go-toolset:1.21 \
  --build-arg RDURL_ARG=https://<internal-registry>/artifactory/ibm-mq-redist-generic-remote \
  --build-arg GOPROXY=https://<internal-registry>/artifactory/api/go/go-virtual \
  --build-arg RUNTIME_IMAGE=<internal-registry>/ubi8-minimal:latest \
  .
```

Verified:

- Build completes successfully using only internal registry, Go proxy, and MQ artifact repository.
- Go toolchain selection works as expected via `GOTOOLCHAIN`.
- MQ client package is resolved from the overridden internal repository.
- The built image was deployed and successfully connected to a queue manager.
- Metrics were collected and exposed correctly.
- Default (public) build remains fully functional.

---

## Issues

N/A (no linked issue)